### PR TITLE
Duplicated bang key doesn't get erased.

### DIFF
--- a/lsapi/BangManager.cpp
+++ b/lsapi/BangManager.cpp
@@ -44,8 +44,9 @@ BOOL BangManager::AddBangCommand(Bang *pbbBang)
 
     if (iter != bang_map.end())
     {
-        iter->second->Release();
+        Bang * bang = iter->second;
         bang_map.erase(iter);
+        bang->Release(); // We must erase before we release since the key is stored inside the Bang.
     }
 
     bang_map.emplace(pbbBang->GetCommand(), pbbBang);


### PR DESCRIPTION
Fix while implementing UnsortedMaps only applied to RemoveBangCommand.